### PR TITLE
Make the coordinate frames of the panels use the same convention as the kite body frame

### DIFF
--- a/src/body_aerodynamics.jl
+++ b/src/body_aerodynamics.jl
@@ -216,14 +216,14 @@ function calculate_panel_properties(section_list::Vector{Section}, n_panels::Int
         bound_2 = section["p2"] * 0.75 + section["p3"] * 0.25
         
         # Calculate reference frame vectors
-        x_airf_vec = cross(VSM_point - LL_point, section["p1"] - section["p2"])
+        z_airf_vec = cross(VSM_point - LL_point, section["p1"] - section["p2"])
+        z_airf_vec = z_airf_vec / norm(z_airf_vec)
+        
+        x_airf_vec = VSM_point - LL_point
         x_airf_vec = x_airf_vec / norm(x_airf_vec)
         
-        y_airf_vec = VSM_point - LL_point
+        y_airf_vec = bound_1 - bound_2
         y_airf_vec = y_airf_vec / norm(y_airf_vec)
-        
-        z_airf_vec = bound_1 - bound_2
-        z_airf_vec = z_airf_vec / norm(z_airf_vec)
         
         # Store results
         push!(aero_centers, LL_point)
@@ -368,8 +368,8 @@ end
 """
     update_effective_angle_of_attack_if_VSM(body_aero::BodyAerodynamics, gamma::Vector{Float64},
                                           core_radius_fraction::Float64,
+                                          z_airf_array::Matrix{Float64},
                                           x_airf_array::Matrix{Float64},
-                                          y_airf_array::Matrix{Float64},
                                           va_array::Matrix{Float64},
                                           va_norm_array::Vector{Float64},
                                           va_unit_array::Matrix{Float64})
@@ -382,8 +382,8 @@ Returns:
 function update_effective_angle_of_attack_if_VSM(body_aero::BodyAerodynamics, 
     gamma::Vector{Float64},
     core_radius_fraction::Float64,
+    z_airf_array::Matrix{Float64},
     x_airf_array::Matrix{Float64},
-    y_airf_array::Matrix{Float64},
     va_array::Matrix{Float64},
     va_norm_array::Vector{Float64},
     va_unit_array::Matrix{Float64})
@@ -404,8 +404,8 @@ function update_effective_angle_of_attack_if_VSM(body_aero::BodyAerodynamics,
     
     # Calculate relative velocities and angles
     relative_velocity = va_array + induced_velocity
-    v_normal = sum(x_airf_array .* relative_velocity, dims=2)
-    v_tangential = sum(y_airf_array .* relative_velocity, dims=2)
+    v_normal = sum(z_airf_array .* relative_velocity, dims=2)
+    v_tangential = sum(x_airf_array .* relative_velocity, dims=2)
     alpha_array = atan.(v_normal ./ v_tangential)
     return alpha_array
 end
@@ -472,8 +472,8 @@ function calculate_results(
             body_aero,
             gamma_new,
             core_radius_fraction,
+            z_airf_array,
             x_airf_array,
-            y_airf_array,
             va_array,
             va_norm_array,
             va_unit_array
@@ -513,20 +513,17 @@ function calculate_results(
     for (i, panel) in enumerate(panels)
         ### Lift and Drag ###
         # Panel geometry
-        z_airf_span = panel.z_airf
-        y_airf_chord = panel.y_airf
-        x_airf_normal = panel.x_airf
         panel_area = panel.chord * panel.width
         area_all_panels += panel_area
 
         # Calculate induced velocity direction
         alpha_corrected_i = alpha_corrected[i]
-        induced_va_airfoil = cos(alpha_corrected_i) * y_airf_chord + 
-                            sin(alpha_corrected_i) * x_airf_normal
+        induced_va_airfoil = cos(alpha_corrected_i) * panel.x_airf + 
+                            sin(alpha_corrected_i) * panel.z_airf
         dir_induced_va_airfoil = induced_va_airfoil / norm(induced_va_airfoil)
 
         # Calculate lift and drag directions
-        dir_lift_induced_va = cross(dir_induced_va_airfoil, z_airf_span)
+        dir_lift_induced_va = cross(dir_induced_va_airfoil, panel.y_airf)
         dir_lift_induced_va = dir_lift_induced_va / norm(dir_lift_induced_va)
         dir_drag_induced_va = cross(spanwise_direction, dir_lift_induced_va)
         dir_drag_induced_va = dir_drag_induced_va / norm(dir_drag_induced_va)
@@ -571,8 +568,8 @@ function calculate_results(
 
         # (2) Convert local (2D) pitching moment to a 3D vector in body coords.
         #     Use the axis around which the moment is defined,
-        #     which is the z-axis pointing "spanwise"
-        moment_axis_body = panel.z_airf
+        #     which is the y-axis pointing "spanwise"
+        moment_axis_body = panel.y_airf
 
         # Scale by panel width if your 'moment[i]' is 2D moment-per-unit-span:
         M_local_3D = moment[i] * moment_axis_body * panel.width
@@ -601,8 +598,8 @@ function calculate_results(
 
     # Calculate geometric angle of attack
     horizontal_direction = [1.0, 0.0, 0.0]
-    alpha_geometric = [rad2deg(acos(dot(panel.y_airf, horizontal_direction) /
-                     (norm(panel.y_airf) * norm(horizontal_direction))))
+    alpha_geometric = [rad2deg(acos(dot(panel.x_airf, horizontal_direction) /
+                     (norm(panel.x_airf) * norm(horizontal_direction))))
                      for panel in panels]
 
     # Calculate Reynolds number

--- a/src/panel.jl
+++ b/src/panel.jl
@@ -26,9 +26,9 @@ Represents a panel in a vortex step method simulation. All points and vectors ar
 - `control_point`::Vector{MVec3}: Panel control point
 - `bound_point_1`::Vector{MVec3}: First bound point
 - `bound_point_2`::Vector{MVec3}: Second bound point
-- `x_airf`::MVec3=zeros(MVec3): Unit vector perpendicular to chord line
-- `y_airf`::MVec3=zeros(MVec3): Unit vector parallel to chord line
-- `z_airf`::MVec3=zeros(MVec3): Unit vector in spanwise direction
+- `x_airf`::MVec3=zeros(MVec3): Unit vector tangential to chord line
+- `y_airf`::MVec3=zeros(MVec3): Unit vector in spanwise direction
+- `z_airf`::MVec3=zeros(MVec3): Unit vector, cross product of x_airf and y_airf
 - `width`::Float64=0: Panel width
 - filaments::Tuple{BoundFilament,BoundFilament,BoundFilament,SemiInfiniteFilament,SemiInfiniteFilament} = (
         BoundFilament(),
@@ -212,8 +212,8 @@ function calculate_relative_alpha_and_relative_velocity(
     # Calculate relative velocity and angle of attack
     # Constants throughout iterations: panel.va, panel.x_airf, panel.y_airf
     relative_velocity = panel.va .+ induced_velocity
-    v_normal = dot(panel.x_airf, relative_velocity)
-    v_tangential = dot(panel.y_airf, relative_velocity)
+    v_normal = dot(panel.z_airf, relative_velocity)
+    v_tangential = dot(panel.x_airf, relative_velocity)
     alpha = atan(v_normal / v_tangential)
     
     return alpha, relative_velocity
@@ -291,8 +291,8 @@ Calculate relative angle of attack and relative velocity of the panel.
 """
 function calculate_relative_alpha_and_velocity(panel::Panel, induced_velocity::Vector{Float64})
     relative_velocity = panel.va + induced_velocity
-    v_normal = dot(panel.x_airf, relative_velocity)
-    v_tangential = dot(panel.y_airf, relative_velocity)
+    v_normal = dot(panel.z_airf, relative_velocity)
+    v_tangential = dot(panel.x_airf, relative_velocity)
     alpha = atan(v_normal / v_tangential)
     return alpha, relative_velocity
 end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -234,17 +234,17 @@ function gamma_loop(
         for i in 1:n_panels
             relative_velocity_crossz[i, :] .= cross3(
                 view(relative_velocity_array, i, :),
-                view(z_airf_array, i, :)
+                view(y_airf_array, i, :)
             )
             v_acrossz_array[i, :] .= cross3(
                 view(va_array, i, :),
-                view(z_airf_array, i, :)
+                view(y_airf_array, i, :)
             )
         end
 
         for i in 1:n_panels
-            v_normal_array[i] = dot(view(x_airf_array, i, :), view(relative_velocity_array, i, :))
-            v_tangential_array[i] = dot(view(y_airf_array, i, :), view(relative_velocity_array, i, :))
+            v_normal_array[i] = dot(view(z_airf_array, i, :), view(relative_velocity_array, i, :))
+            v_tangential_array[i] = dot(view(x_airf_array, i, :), view(relative_velocity_array, i, :))
         end
         alpha_array .= atan.(v_normal_array, v_tangential_array)
 

--- a/test/test_body_aerodynamics.jl
+++ b/test/test_body_aerodynamics.jl
@@ -179,8 +179,8 @@ end
         [calculate_cd_cm(panel, alpha[i])[2] for (i, panel) in enumerate(body_aero.panels)]
     )
     
-    ringvec = [Dict("r0" => panel.width * panel.z_airf) for panel in body_aero.panels]
-    controlpoints = [Dict("tangential" => panel.y_airf, "normal" => panel.x_airf) 
+    ringvec = [Dict("r0" => panel.width * panel.y_airf) for panel in body_aero.panels]
+    controlpoints = [Dict("tangential" => panel.x_airf, "normal" => panel.z_airf) 
                     for panel in body_aero.panels]
     Atot = calculate_projected_area(wing)
 
@@ -285,10 +285,10 @@ end
 
                 @test isapprox(evaluation_point, expected_controlpoints[i]["coordinates"], atol=1e-4)
                 @test isapprox(panel.chord, expected_controlpoints[i]["chord"], atol=1e-4)
-                @test isapprox(panel.x_airf, expected_controlpoints[i]["normal"], atol=1e-4)
-                @test isapprox(panel.y_airf, expected_controlpoints[i]["tangential"], atol=1e-4)
+                @test isapprox(panel.z_airf, expected_controlpoints[i]["normal"], atol=1e-4)
+                @test isapprox(panel.x_airf, expected_controlpoints[i]["tangential"], atol=1e-4)
                 @test isapprox(
-                    hcat(panel.x_airf, panel.y_airf, panel.z_airf),
+                    hcat(panel.z_airf, panel.x_airf, panel.y_airf),
                     expected_controlpoints[i]["airf_coord"],
                     atol=1e-4
                 )

--- a/test/test_panel.jl
+++ b/test/test_panel.jl
@@ -24,16 +24,16 @@ function create_panel(section1::Section, section2::Section)
 
     LLpoint = aero_center
     VSMpoint = control_point
-    x_airf = cross(VSMpoint .- LLpoint, section["p2"] .- section["p1"])
-    x_airf = x_airf ./ norm(x_airf)
+    z_airf = cross(VSMpoint .- LLpoint, section["p2"] .- section["p1"])
+    z_airf = z_airf ./ norm(z_airf)
 
     # TANGENTIAL y_airf defined parallel to the chord-line
-    y_airf = VSMpoint .- LLpoint
-    y_airf = y_airf ./ norm(y_airf)
+    x_airf = VSMpoint .- LLpoint
+    x_airf = x_airf ./ norm(x_airf)
 
-    # SPAN z_airf along the LE
-    z_airf = bound_2 .- bound_1
-    z_airf = z_airf ./ norm(z_airf)
+    # SPAN y_airf along the LE
+    y_airf = bound_2 .- bound_1
+    y_airf = y_airf ./ norm(y_airf)
 
     panel = Panel()
     init!(
@@ -89,9 +89,9 @@ end
         panel = create_panel(section1, section2)
 
         # Test reference frame vectors
-        @test isapprox(panel.x_airf, [0.0, 0.0, 1.0])
-        @test isapprox(panel.y_airf, [1.0, 0.0, 0.0])
-        @test isapprox(panel.z_airf, [0.0, 1.0, 0.0])
+        @test isapprox(panel.z_airf, [0.0, 0.0, 1.0])
+        @test isapprox(panel.x_airf, [1.0, 0.0, 0.0])
+        @test isapprox(panel.y_airf, [0.0, 1.0, 0.0])
     end
 
     @testset "Velocity Calculations" begin
@@ -105,8 +105,8 @@ end
         alpha, rel_vel = calculate_relative_alpha_and_relative_velocity(panel, induced_velocity)
         
         # Verify calculations
-        norm_airf = panel.x_airf
-        tan_airf = panel.y_airf
+        norm_airf = panel.z_airf
+        tan_airf = panel.x_airf
         relative_velocity = panel.va .+ induced_velocity
         vn = dot(norm_airf, relative_velocity)
         vtan = dot(tan_airf, relative_velocity)


### PR DESCRIPTION
This way, the panel frames align with the body frame of a rectangular wing and they are easier to understand.

x_airf along chord from le to te
y_airf spanwise
z_airf = x_airf cross y_airf