### PR TITLE
Add origin parameter to BodyAerodynamics constructor

### DIFF
--- a/docs/src/reference_frames.md
+++ b/docs/src/reference_frames.md
@@ -21,7 +21,7 @@ This is a body-fixed reference frame.
 - X is defined chord wise, from LE to TE, positive.
 - Z is defined as the cross product of Y and X
 
-The origin of the kite reference frame can be defined by the user by calling the function `init_kb(origin::MVec3)` where the origin must be defined in the `CAD` reference frame.
+The origin of the kite reference frame can be defined by the user by passing the keyword argument `kite_body_origin = ...` to the `BodyAerodynamics` constructor.
 
 This reference frame is different from the kite reference frame **K** used in `KiteModels.jl` and `KiteUtils.jl`.
 

--- a/examples/ram_air_kite.jl
+++ b/examples/ram_air_kite.jl
@@ -14,7 +14,7 @@ PLOT = true
 
 # Create wing geometry
 wing = KiteWing("data/ram_air_kite_body.obj", "data/ram_air_kite_foil.dat")
-body_aero = BodyAerodynamics([wing])
+body_aero = BodyAerodynamics([wing]; kite_body_origin=wing.center_of_mass)
 
 alpha = [0, 0]
 beta = [deg2rad(10), 0]

--- a/src/body_aerodynamics.jl
+++ b/src/body_aerodynamics.jl
@@ -33,14 +33,37 @@ Main structure for calculating aerodynamic properties of bodies.
     AIC::Array{Float64, 3} = zeros(3, P, P)
 end
 
+"""
+    BodyAerodynamics(wings::Vector{T}; aero_center_location=0.25,
+                     control_point_location=0.75,
+                     kite_body_origin=zeros(MVec3)) where T <: AbstractWing
+
+Construct a [BodyAerodynamics](@ref) object for aerodynamic calculations.
+
+# Arguments
+- `wings::Vector{T}`: Vector of wings to analyze, where T is an AbstractWing type
+
+# Keyword Arguments
+- `aero_center_location=0.25`: Chordwise location of aerodynamic center (0-1)
+- `control_point_location=0.75`: Chordwise location of control point (0-1) 
+- `kite_body_origin=zeros(MVec3)`: Origin point of kite body coordinate system
+
+# Returns
+- [BodyAerodynamics](@ref) object initialized with panels and wings
+"""
 function BodyAerodynamics(
     wings::Vector{T};
     aero_center_location=0.25,
-    control_point_location=0.75
+    control_point_location=0.75,
+    kite_body_origin=zeros(MVec3)
 ) where T <: AbstractWing
     # Initialize panels
     panels = Panel[]
     for wing in wings
+        for section in sections
+            section.LE_point .-= kite_body_origin
+            section.TE_point .-= kite_body_origin
+        end
         if wing.spanwise_panel_distribution == UNCHANGED
             wing.n_panels = length(wing.sections) - 1
             wing.refined_sections = wing.sections
@@ -60,6 +83,23 @@ function BodyAerodynamics(
     return body_aero
 end
 
+"""
+    init!(body_aero::BodyAerodynamics; 
+         aero_center_location=0.25,
+         control_point_location=0.75)
+
+Initialize a BodyAerodynamics struct in-place by setting up panels and coefficients.
+
+# Arguments
+- `body_aero::BodyAerodynamics`: The structure to initialize
+
+# Keyword Arguments
+- `aero_center_location=0.25`: Chordwise location of aerodynamic center (0-1)
+- `control_point_location=0.75`: Chordwise location of control point (0-1)
+
+# Returns
+nothing
+"""
 function init!(body_aero::BodyAerodynamics; 
     aero_center_location=0.25,
     control_point_location=0.75)

--- a/src/body_aerodynamics.jl
+++ b/src/body_aerodynamics.jl
@@ -60,7 +60,7 @@ function BodyAerodynamics(
     # Initialize panels
     panels = Panel[]
     for wing in wings
-        for section in sections
+        for section in wing.sections
             section.LE_point .-= kite_body_origin
             section.TE_point .-= kite_body_origin
         end

--- a/src/body_aerodynamics.jl
+++ b/src/body_aerodynamics.jl
@@ -46,7 +46,7 @@ Construct a [BodyAerodynamics](@ref) object for aerodynamic calculations.
 # Keyword Arguments
 - `aero_center_location=0.25`: Chordwise location of aerodynamic center (0-1)
 - `control_point_location=0.75`: Chordwise location of control point (0-1) 
-- `kite_body_origin=zeros(MVec3)`: Origin point of kite body coordinate system
+- `kite_body_origin=zeros(MVec3)`: Origin point of kite body reference frame in CAD reference frame
 
 # Returns
 - [BodyAerodynamics](@ref) object initialized with panels and wings

--- a/test/test_body_aerodynamics.jl
+++ b/test/test_body_aerodynamics.jl
@@ -228,6 +228,26 @@ end
 end
 
 @testset "Wing Geometry Creation" begin
+    @testset "Origin Translation" begin
+        # Create minimal wing with three sections (2 panels)
+        wing = Wing(2)
+        add_section!(wing, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], INVISCID)
+        add_section!(wing, [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], INVISCID)
+        add_section!(wing, [0.0, 2.0, 0.0], [1.0, 2.0, 0.0], INVISCID)
+    
+        # Test non-zero origin translation
+        origin = MVec3(1.0, 2.0, 3.0)
+        body_aero = BodyAerodynamics([wing]; kite_body_origin=origin)
+        
+        # Check if sections are correctly translated
+        @test wing.sections[3].LE_point ≈ [-1.0, -2.0, -3.0]
+        @test wing.sections[3].TE_point ≈ [0.0, -2.0, -3.0]
+        @test wing.sections[2].LE_point ≈ [-1.0, -1.0, -3.0]
+        @test wing.sections[2].TE_point ≈ [0.0, -1.0, -3.0]
+        @test wing.sections[1].LE_point ≈ [-1.0, 0.0, -3.0]
+        @test wing.sections[1].TE_point ≈ [0.0, 0.0, -3.0]
+    end
+
     function create_geometry(; model=VSM, wing_type=:rectangular, plotting=false, N=40)
         max_chord = 1.0
         span = 17.0


### PR DESCRIPTION
Wings are initialized in CAD frame and are translated to the kite body frame using the kite_body_origin keyword argument.