### PR TITLE
Add installer for examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- added the function `install_examples()` which allows to easily install the examples without using `git`
+
 ## VortexStepMethod v1.1.0 2025-03-04
 ### Added
 - Dynamically deform the KiteWing by twisting the left side and right side, and deforming the trailing edges using deform! #19

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ julia -e 'using Pkg; Pkg.add("TestEnv"); Pkg.add("ControlPlots")'
 
 Before installing this software it is suggested to create a new project, for example like this:
 ```bash
-mkdir test
-cd test
+mkdir vsm
+cd vsm
 julia --project=.
 ```
 Then add VortexStepMethod from  Julia's package manager, by typing:
@@ -38,8 +38,14 @@ at the Julia prompt. You can run the unit tests with the command:
 ```julia
 pkg"test VortexStepMethod"
 ```
+To run the examples, type:
+```julia
+using VortexStepMethod
+VortexStepMethod.install_examples()
+include("examples/menu.jl")
+```
 
-## Running the examples
+## Running the examples as developer
 If you have git installed, check out this repo because it makes it easier to understand the code:
 ```bash
 mkdir repos

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,8 +26,8 @@ julia -e 'using Pkg; Pkg.add("TestEnv"); Pkg.add("ControlPlots")'
 
 Before installing this software it is suggested to create a new project, for example like this:
 ```bash
-mkdir test
-cd test
+mkdir vsm
+cd vsm
 julia --project=.
 ```
 Then add VortexStepMethod from  Julia's package manager, by typing:
@@ -39,8 +39,14 @@ at the Julia prompt. You can run the unit tests with the command:
 ```julia
 pkg"test VortexStepMethod"
 ```
+To run the examples, type:
+```julia
+using VortexStepMethod
+VortexStepMethod.install_examples()
+include("examples/menu.jl")
+```
 
-## Running the examples
+## Running the examples as developer
 If you have git installed, check out this repo because it makes it easier to understand the code:
 ```bash
 mkdir repos

--- a/examples/menu.jl
+++ b/examples/menu.jl
@@ -10,6 +10,7 @@ function help()
     else
         io = IOBuffer()
         run(pipeline(`xdg-open $url`, stderr = io))
+        # ignore any error messages
         out_data = String(take!(io)) 
     end
     nothing

--- a/examples/menu.jl
+++ b/examples/menu.jl
@@ -15,7 +15,12 @@ function help()
     nothing
 end
 
-options = ["help_me = help()",
+options = ["rectangular_wing = include(\"rectangular_wing.jl\")",
+           "ram_air_kite = include(\"ram_air_kite.jl\")",
+           "stall_model = include(\"stall_model.jl\")",
+           "bench = include(\"bench.jl\")",
+           "cleanup = include(\"cleanup.jl\")",
+           "help_me = help()",
            "quit"]
 
 function example_menu()

--- a/examples/menu.jl
+++ b/examples/menu.jl
@@ -4,18 +4,21 @@ using REPL.TerminalMenus
 
 url = "https://albatross-kite-transport.github.io/VortexStepMethod.jl/dev"
 
-help_command = if Sys.iswindows()
-    "run(`cmd /c start $url`)"
-else
-    "run(`xdg-open $url`)"
+function help() 
+    if Sys.iswindows()
+        run(`cmd /c start $url`)
+    else
+        run(`xdg-open $url`)
+    end
+    nothing
 end
 
-options = ["rectangular_wing = include(\"rectangular_wing.jl\")",
+options = ["rectangular_wing = include(\"rectangular_wing.jl"\")",
            "ram_air_kite = include(\"ram_air_kite.jl\")",
            "stall_model = include(\"stall_model.jl\")",
            "bench = include(\"bench.jl\")",
            "cleanup = include(\"cleanup.jl\")",
-           "help = $help_command",
+           "help = help()",
            "quit"]
 
 function example_menu()

--- a/examples/menu.jl
+++ b/examples/menu.jl
@@ -8,17 +8,14 @@ function help()
     if Sys.iswindows()
         run(`cmd /c start $url`)
     else
-        run(`xdg-open $url`)
+        io = IOBuffer()
+        run(pipeline(`xdg-open $url`, stderr = io))
+        out_data = String(take!(io)) 
     end
     nothing
 end
 
-options = ["rectangular_wing = include(\"rectangular_wing.jl"\")",
-           "ram_air_kite = include(\"ram_air_kite.jl\")",
-           "stall_model = include(\"stall_model.jl\")",
-           "bench = include(\"bench.jl\")",
-           "cleanup = include(\"cleanup.jl\")",
-           "help = help()",
+options = ["help_me = help()",
            "quit"]
 
 function example_menu()

--- a/src/VortexStepMethod.jl
+++ b/src/VortexStepMethod.jl
@@ -169,6 +169,44 @@ function menu()
    Main.include("examples/menu.jl")
 end
 
+"""
+    copy_examples()
+
+Copy all example scripts to the folder "examples"
+(it will be created if it doesn't exist).
+"""
+function copy_examples()
+    PATH = "examples"
+    if ! isdir(PATH) 
+        mkdir(PATH)
+    end
+    src_path = joinpath(dirname(pathof(@__MODULE__)), "..", PATH)
+    copy_files("examples", readdir(src_path))
+end
+
+function install_examples(add_packages=true)
+    copy_examples()
+    if add_packages
+        Pkg.add("ControlPlots")
+        Pkg.add("LaTeXStrings")
+        Pkg.add("Xfoil")
+        Pkg.add("CSV")
+        Pkg.add("DataFrames")
+    end
+end
+
+function copy_files(relpath, files)
+    if ! isdir(relpath) 
+        mkdir(relpath)
+    end
+    src_path = joinpath(dirname(pathof(@__MODULE__)), "..", relpath)
+    for file in files
+        cp(joinpath(src_path, file), joinpath(relpath, file), force=true)
+        chmod(joinpath(relpath, file), 0o774)
+    end
+    files
+end
+
 # Include core functionality
 include("wing_geometry.jl")
 include("kite_geometry.jl")

--- a/src/VortexStepMethod.jl
+++ b/src/VortexStepMethod.jl
@@ -14,6 +14,7 @@ using Interpolations: Extrapolation
 using Parameters
 using Serialization
 using SharedArrays
+using Pkg
 
 # Export public interface
 export Wing, Section, KiteWing

--- a/src/VortexStepMethod.jl
+++ b/src/VortexStepMethod.jl
@@ -188,11 +188,21 @@ end
 function install_examples(add_packages=true)
     copy_examples()
     if add_packages
-        Pkg.add("ControlPlots")
-        Pkg.add("LaTeXStrings")
-        Pkg.add("Xfoil")
-        Pkg.add("CSV")
-        Pkg.add("DataFrames")
+        if ! ("ControlPlots" ∈ keys(Pkg.project().dependencies))
+            Pkg.add("ControlPlots")
+        end
+        if ! ("LaTeXStrings" ∈ keys(Pkg.project().dependencies))
+            Pkg.add("LaTeXStrings")
+        end
+        if ! ("Xfoil" ∈ keys(Pkg.project().dependencies))
+            Pkg.add("Xfoil")
+        end
+        if ! ("CSV" ∈ keys(Pkg.project().dependencies))
+            Pkg.add("CSV")
+        end
+        if ! ("DataFrames" ∈ keys(Pkg.project().dependencies))
+            Pkg.add("DataFrames")
+        end
     end
 end
 


### PR DESCRIPTION
- [x] add function install_examples()
- [x] improve help function on Linux (no long string, no error messages)
- [ ] update README.md

For testing do:

The following should work:
```bash
mkdir vsm
cd vsm
julia --project=.
```
```julia
using Pkg
pkg"add VortexStepMethod#installer"
using VortexStepMethod
VortexStepMethod.install_examples()
include("examples/menu.jl")
```