### PR TITLE
Add examples using ControlPlots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ hooks
 .vscode
 .idea
 Manifest-v1.11.toml.default
+results/TUDELFT_V3_KITE/polars/tutorial_testing_stall_model_n_panels_54_distribution_SPLIT_PROVIDED.pdf

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["1-Bart-1 <bart@vandelint.net>", "Oriol Cayon and contributors"]
 version = "3.0.1"
 
 [workspace]
-projects = ["examples", "docs", "test"]
+projects = ["examples", "examples_cp", "docs", "test"]
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/bin/install
+++ b/bin/install
@@ -191,7 +191,7 @@ if ! instantiate_main_with_fallback "." "main"; then
     exit 1
 fi
 
-SUBPROJECTS=("examples" "test" "docs" "scripts")
+SUBPROJECTS=("examples" "examples_cp" "test" "docs" "scripts")
 
 echo
 echo "Instantiating sub-projects..."
@@ -230,7 +230,7 @@ else
     exit 1
 fi
 
-julia --project=. -e 'using Pkg; Pkg.precompile(); Pkg.activate("examples"); Pkg.precompile(); using LinearAlgebra, GLMakie, VortexStepMethod; @info "Precompilation complete."'
+$_julia_cmd --project=. -e 'using Pkg; Pkg.precompile(); Pkg.activate("examples"); Pkg.precompile(); Pkg.activate("examples_cp"); Pkg.precompile(); using LinearAlgebra, GLMakie, VortexStepMethod; @info "Precompilation complete."'
 echo
 echo "Installation complete."
 

--- a/bin/jetls_examples
+++ b/bin/jetls_examples
@@ -9,6 +9,9 @@ fi
 
 echo -e "\033[1mInstalling dependencies...\033[0m"
 julia --project=examples -e 'using Pkg; Pkg.instantiate()'
+julia --project=examples_cp -e 'using Pkg; Pkg.instantiate()'
 echo -e "\033[1mChecking examples with jetls...\033[0m"
-jetls -t 1,0 -- check --root=. examples/*.jl
+jetls check --root=. examples/*.jl
+echo -e "\033[1mChecking examples_cp with jetls...\033[0m"
+jetls -t 1,0 -- check --root=. examples_cp/*.jl
 echo

--- a/bin/run_julia
+++ b/bin/run_julia
@@ -9,7 +9,7 @@ export JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager
 if [[ $# -gt 0 ]]; then
     JULIA_ARGS=("$@")
 else
-    JULIA_ARGS=(-i -e 'using VortexStepMethod; function menu(); include("examples/menu.jl"); end')
+    JULIA_ARGS=(-i -e 'using VortexStepMethod; function menu(); include("examples/menu.jl"); end; function menu_cp(); include("examples_cp/menu_cp.jl"); end')
 fi
 
 julia --project "${JULIA_ARGS[@]}"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-ControlPlots = "23c2ee80-7a9e-4350-b264-8e670f12517c"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"

--- a/examples_cp/Project.toml
+++ b/examples_cp/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+ControlPlots = "23c2ee80-7a9e-4350-b264-8e670f12517c"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+VortexStepMethod = "ed3cd733-9f0f-46a9-93e0-89b8d4998dd9"
+
+[sources]
+VortexStepMethod = {path = ".."}

--- a/examples_cp/V3_kite.jl
+++ b/examples_cp/V3_kite.jl
@@ -1,0 +1,151 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using LinearAlgebra
+using VortexStepMethod
+using ControlPlots
+
+PLOT = true
+USE_TEX = false
+DEFORM = false
+
+project_dir = dirname(@__DIR__)
+literature_paths = [
+    joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "CFD_RANS_Rey_5e5_Poland2025_alpha_sweep_beta_0_NoStruts.csv"),
+    joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "CFD_RANS_Rey_10e5_Poland2025_alpha_sweep_beta_0.csv"),
+    joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "python_alpha_sweep.csv"),
+    joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "windtunnel_alpha_sweep_beta_00_0_Poland_2025_Rey_5e5.csv"),
+]
+labels = [
+    "VSM Julia Re=5e5",
+    "CFD Re=5e5",
+    "CFD Re=10e5", #with struts
+    "VSM Python Re=5e5",
+    "WindTunnel Re=5e5" #with struts
+]
+beta_literature_paths = [
+    joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "windtunnel_beta_sweep_alpha_07_4_Poland_2025_Rey_5e5.csv"),
+    # joinpath(project_dir, "data", "TUDELFT_V3_KITE", "literature_results", "windtunnel_beta_sweep_alpha_12_5_Poland_2025_Rey_5e5.csv"),
+]
+beta_labels = [
+    labels[1],
+    "Wind Tunnel Re=5e5 beta sweep alpha=7.4",
+    # "Wind Tunnel Re=5e5 beta sweep alpha=12.5",
+]
+
+# Load YAML settings directly (avoids VSMSettings(filename) conversion issues in live sessions)
+settings_path = joinpath(project_dir, "data", "TUDELFT_V3_KITE", "vsm_settings.yaml")
+settings_data = VortexStepMethod.YAML.load_file(settings_path)
+condition_cfg = settings_data["condition"]
+wing_cfg = settings_data["wings"][1]
+solver_cfg = settings_data["solver_settings"]
+
+# Create wing, body_aero, and solver objects using settings
+
+wing = Wing(
+    joinpath(project_dir, wing_cfg["geometry_file"]);
+    n_panels=wing_cfg["n_panels"],
+    spanwise_distribution=getproperty(VortexStepMethod, Symbol(wing_cfg["spanwise_panel_distribution"])),
+    spanwise_direction=Float64.(wing_cfg["spanwise_direction"]),
+    remove_nan=wing_cfg["remove_nan"],
+)
+refine!(wing)
+body_aero = BodyAerodynamics([wing])
+VortexStepMethod.reinit!(body_aero)
+
+if DEFORM
+    VortexStepMethod.unrefined_deform!(
+        wing,
+        deg2rad.(range(-10, 10, length=wing.n_unrefined_sections)),
+        deg2rad.(range(0, 0, length=wing.n_unrefined_sections));
+        smooth=true
+    )
+    VortexStepMethod.reinit!(body_aero; init_aero=false)
+end
+
+
+# Construct Solver using keyword arguments from solver settings
+solver = Solver(body_aero;
+    solver_type=(solver_cfg["solver_type"] == "NONLIN" ? NONLIN : LOOP),
+    aerodynamic_model_type=getproperty(VortexStepMethod, Symbol(solver_cfg["aerodynamic_model_type"])),
+    density=solver_cfg["density"],
+    max_iterations=solver_cfg["max_iterations"],
+    rtol=solver_cfg["rtol"],
+    tol_reference_error=solver_cfg["tol_reference_error"],
+    relaxation_factor=solver_cfg["relaxation_factor"],
+    is_with_artificial_damping=solver_cfg["artificial_damping"],
+    artificial_damping=(k2=solver_cfg["k2"], k4=solver_cfg["k4"]),
+    type_initial_gamma_distribution=getproperty(VortexStepMethod, Symbol(solver_cfg["type_initial_gamma_distribution"])),
+    use_gamma_prev=get(solver_cfg, "use_gamma_prev", get(solver_cfg, "use_gamme_prev", true)),
+    core_radius_fraction=solver_cfg["core_radius_fraction"],
+    mu=solver_cfg["mu"],
+    is_only_f_and_gamma_output=get(solver_cfg, "calc_only_f_and_gamma", false),
+    correct_aoa=get(solver_cfg, "correct_aoa", false),
+    reference_point=get(solver_cfg, "reference_point", [0.422646, 0.0, 9.3667]), #ref-point from WT exp.
+)
+
+# Extract values for plotting (optional - for reference)
+wind_speed = condition_cfg["wind_speed"]
+angle_of_attack_deg = condition_cfg["alpha"]
+sideslip_deg = condition_cfg["beta"]
+yaw_rate = condition_cfg["yaw_rate"]
+
+# Set flight conditions from settings
+α0 = deg2rad(angle_of_attack_deg)
+β0 = deg2rad(sideslip_deg)
+set_va!(body_aero, wind_speed .* [cos(α0) * cos(β0), sin(β0), sin(α0) * cos(β0)])
+
+# Solve and plot combined analysis
+results = VortexStepMethod.solve(solver, body_aero; log=true)
+# Plotting polars
+PLOT && plot_polars(
+    [solver],
+    [body_aero],
+    labels,
+    literature_path_list=literature_paths,
+    angle_range=range(-5, 25, length=31),
+    angle_type="angle_of_attack",
+    angle_of_attack=angle_of_attack_deg,
+    side_slip=sideslip_deg,
+    v_a=wind_speed,
+    title="$(wing.n_panels)_panels_$(wing.spanwise_distribution)_from_yaml_settings",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+
+# Plotting geometry
+results = VortexStepMethod.solve(solver, body_aero; log=true)
+PLOT && plot_geometry(
+    body_aero,
+    "";
+    data_type=".svg",
+    save_path="",
+    is_save=false,
+    is_show=true,
+    view_elevation=15,
+    view_azimuth=-120,
+    use_tex=USE_TEX
+)
+
+
+# Plotting spanwise distributions
+body_y_coordinates = [panel.aero_center[2] for panel in body_aero.panels]
+
+PLOT && plot_distribution(
+    [body_y_coordinates],
+    [results],
+    ["VSM"];
+    title="CAD_spanwise_distributions_alpha_$(round(angle_of_attack_deg, digits=1))_delta_$(round(sideslip_deg, digits=1))_yaw_$(round(yaw_rate, digits=1))_v_a_$(round(wind_speed, digits=1))",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+
+nothing

--- a/examples_cp/V3_kite.jl
+++ b/examples_cp/V3_kite.jl
@@ -119,7 +119,6 @@ PLOT && plot_polars(
 
 
 # Plotting geometry
-results = VortexStepMethod.solve(solver, body_aero; log=true)
 PLOT && plot_geometry(
     body_aero,
     "";

--- a/examples_cp/bench.jl
+++ b/examples_cp/bench.jl
@@ -1,0 +1,99 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using LinearAlgebra
+using ControlPlots
+using VortexStepMethod
+using VortexStepMethod: solve_base!
+
+
+# Step 1: Define wing parameters
+n_panels = 20          # Number of panels
+span = 20.0            # Wing span [m]
+chord = 1.0            # Chord length [m]
+v_a = 20.0             # Magnitude of inflow velocity [m/s]
+density = 1.225        # Air density [kg/m³]
+alpha_deg = 30.0       # Angle of attack [degrees]
+alpha = deg2rad(alpha_deg)
+
+# Step 2: Create wing geometry with linear panel distribution
+wing = Wing(n_panels, spanwise_distribution=LINEAR)
+
+# Add wing sections - defining only tip sections with inviscid airfoil model
+add_section!(wing, 
+    [0.0, span/2, 0.0],    # Left tip LE 
+    [chord, span/2, 0.0],  # Left tip TE
+    INVISCID)
+add_section!(wing, 
+    [0.0, -span/2, 0.0],   # Right tip LE
+    [chord, -span/2, 0.0], # Right tip TE
+    INVISCID)
+
+# Refine mesh
+refine!(wing)
+
+# Step 3: Initialize aerodynamics
+body_aero = BodyAerodynamics([wing])
+
+# Set inflow conditions
+vel_app = [cos(alpha), 0.0, sin(alpha)] .* v_a
+set_va!(body_aero, vel_app)
+
+# Step 4: Initialize solvers for both LLT and VSM methods
+llt_solver = Solver(body_aero; aerodynamic_model_type=LLT)
+vsm_solver = Solver(body_aero; aerodynamic_model_type=VSM)
+
+# Step 5: Solve using both methods
+results_vsm = solve(vsm_solver, body_aero, nothing)
+sol = solve!(vsm_solver, body_aero, nothing)
+results_vsm_base = solve_base!(vsm_solver, body_aero, nothing)
+println("Rectangular wing, solve_base!:")
+@time results_vsm_base = solve_base!(vsm_solver, body_aero, nothing)
+# time Python: 32.0  ms Ryzen 7950x
+# time Julia:   0.42 ms Ryzen 7950x
+println("Rectangular wing, solve!:")
+@time sol = solve!(vsm_solver, body_aero, nothing)
+println("Rectangular wing, solve:")
+@time solve(vsm_solver, body_aero, nothing)
+
+# Create wing geometry
+wing = ObjWing(
+    joinpath("data", "ram_air_kite", "ram_air_kite_body.obj"),
+    joinpath("data", "ram_air_kite", "ram_air_kite_foil.dat");
+    prn=false
+)
+body_aero = BodyAerodynamics([wing])
+
+# Create solvers
+vsm_solver = Solver(
+    body_aero;
+    aerodynamic_model_type=VSM,
+    is_with_artificial_damping=false,
+    solver_type=NONLIN,
+)
+
+# Setting velocity conditions
+v_a = 15.0
+aoa = 15.0
+side_slip = 0.0
+yaw_rate = 0.0
+aoa_rad = deg2rad(aoa)
+vel_app = [
+    cos(aoa_rad) * cos(side_slip),
+    sin(side_slip),
+    sin(aoa_rad)
+] * v_a
+set_va!(body_aero, vel_app)
+
+# Solving
+solve_base!(vsm_solver, body_aero, nothing)
+println("RAM-air kite, solve_base!:")
+@time solve_base!(vsm_solver, body_aero, nothing)
+solve!(vsm_solver, body_aero, nothing)
+println("RAM-air kite, solve!:")
+@time solve!(vsm_solver, body_aero, nothing)
+
+
+nothing

--- a/examples_cp/cleanup.jl
+++ b/examples_cp/cleanup.jl
@@ -1,0 +1,10 @@
+
+# delete the generated polars
+# it is useful if you want to benchmark the polar generation or if you have changed parameters
+
+file1="data/ram_air_kite/ram_air_kite_foil_cl_polar.csv"
+file2="data/ram_air_kite/ram_air_kite_foil_cd_polar.csv"
+file3="data/ram_air_kite/ram_air_kite_foil_cm_polar.csv"
+isfile(file1) && rm(file1)
+isfile(file2) && rm(file2)
+isfile(file3) && rm(file3)

--- a/examples_cp/menu_cp.jl
+++ b/examples_cp/menu_cp.jl
@@ -1,5 +1,9 @@
 using Pkg
+if !("VortexStepMethod" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
 
+using VortexStepMethod
 using REPL.TerminalMenus
 
 url = "https://opensourceawe.github.io/VortexStepMethod.jl/dev"

--- a/examples_cp/menu_cp.jl
+++ b/examples_cp/menu_cp.jl
@@ -1,0 +1,33 @@
+using Pkg
+
+using REPL.TerminalMenus
+
+url = "https://opensourceawe.github.io/VortexStepMethod.jl/dev"
+
+options = [
+           "V3_kite = include(\"V3_kite.jl\")",
+           "pyramid_model = include(\"pyramid_model.jl\")",
+           "rectangular_wing = include(\"rectangular_wing.jl\")",
+           "ram_air_kite = include(\"ram_air_kite.jl\")",
+           "stall_model = include(\"stall_model.jl\")",
+           "bench = include(\"bench.jl\")",
+           "cleanup = include(\"cleanup.jl\")",
+           "help_me = VortexStepMethod.help(url)",
+           "quit"]
+
+function example_menu()
+    active = true
+    while active
+        menu = RadioMenu(options, pagesize=8)
+        choice = request("\nChoose function to execute or `q` to quit: ", menu)
+
+        if choice != -1 && choice != length(options)
+            eval(Meta.parse(options[choice]))
+        else
+            println("Left menu. Press <ctrl><d> to quit Julia!")
+            active = false
+        end
+    end
+end
+
+example_menu()

--- a/examples_cp/pyramid_model.jl
+++ b/examples_cp/pyramid_model.jl
@@ -50,7 +50,6 @@ PLOT && plot_polars(
 )
 
 # Plotting geometry
-results = VortexStepMethod.solve(solver, body_aero; log=true)
 PLOT && plot_geometry(
     body_aero,
     "";

--- a/examples_cp/pyramid_model.jl
+++ b/examples_cp/pyramid_model.jl
@@ -1,0 +1,80 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using LinearAlgebra
+using VortexStepMethod
+using ControlPlots
+
+# Load VSM vsm_settings from YAML configuration file
+vsm_settings = VSMSettings("pyramid_model/vsm_settings.yaml")
+
+# Create wing, body_aero, and solver objects using vsm_settings
+wing = Wing(vsm_settings)
+refine!(wing)
+body_aero = BodyAerodynamics([wing])
+solver = Solver(body_aero, vsm_settings)
+
+# Set flight conditions from settings
+set_va!(body_aero, vsm_settings)
+
+# Extract values for plotting (optional - for reference)
+wind_speed = vsm_settings.condition.wind_speed
+angle_of_attack_deg = vsm_settings.condition.alpha
+sideslip_deg = vsm_settings.condition.beta
+yaw_rate = vsm_settings.condition.yaw_rate
+
+# Run the solver
+results = VortexStepMethod.solve(solver, body_aero; log=true)
+
+# Using plotting modules, to create more comprehensive plots
+PLOT = true
+USE_TEX = false
+
+# Plotting polars
+PLOT && plot_polars(
+    [solver],
+    [body_aero],
+    ["VSM Pyramid Model"],
+    angle_range=range(-5, 25, length=30),
+    angle_type="angle_of_attack",
+    angle_of_attack=angle_of_attack_deg,
+    side_slip=sideslip_deg,
+    v_a=wind_speed,
+    title="$(wing.n_panels)_panels_$(wing.spanwise_distribution)_pyramid_model",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+# Plotting geometry
+results = VortexStepMethod.solve(solver, body_aero; log=true)
+PLOT && plot_geometry(
+    body_aero,
+    "";
+    data_type=".svg",
+    save_path="",
+    is_save=false,
+    is_show=true,
+    view_elevation=15,
+    view_azimuth=-120,
+    use_tex=USE_TEX
+)
+
+# Plotting spanwise distributions
+body_y_coordinates = [panel.aero_center[2] for panel in body_aero.panels]
+
+PLOT && plot_distribution(
+    [body_y_coordinates],
+    [results],
+    ["VSM"];
+    title="pyramid_spanwise_distributions_alpha_$(round(angle_of_attack_deg, digits=1))_delta_$(round(sideslip_deg, digits=1))_yaw_$(round(yaw_rate, digits=1))_v_a_$(round(wind_speed, digits=1))",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+nothing

--- a/examples_cp/ram_air_kite.jl
+++ b/examples_cp/ram_air_kite.jl
@@ -1,0 +1,127 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using ControlPlots
+using VortexStepMethod
+using LinearAlgebra
+
+PLOT = true
+PRN = true
+USE_TEX = false
+DEFORM = true
+const LINEARIZE = false
+
+# Create wing geometry
+wing = ObjWing(
+    joinpath("data", "ram_air_kite", "ram_air_kite_body.obj"),
+    joinpath("data", "ram_air_kite", "ram_air_kite_foil.dat");
+    n_unrefined_sections=2,
+    prn=PRN
+)
+body_aero = BodyAerodynamics([wing];)
+println("First init")
+@time VortexStepMethod.reinit!(body_aero)
+
+if DEFORM
+    # Linear interpolation of alpha from 10° at one tip to 0° at the other
+    println("Deform")
+    @time VortexStepMethod.unrefined_deform!(wing, deg2rad.([-10,0]), deg2rad.([0,0]); smooth=true)
+    println("Deform init")
+    @time VortexStepMethod.reinit!(body_aero; init_aero=false)
+end
+
+# Create solvers
+solver = Solver(body_aero;
+    aerodynamic_model_type=VSM,
+    is_with_artificial_damping=false,
+    rtol=1e-5,
+    solver_type=NONLIN
+)
+
+# Setting velocity conditions
+v_a = 15.0
+aoa = 10.0
+side_slip = 0.0
+yaw_rate = 0.0
+aoa_rad = deg2rad(aoa)
+vel_app = [
+    cos(aoa_rad) * cos(side_slip),
+    sin(side_slip),
+    sin(aoa_rad)
+] * v_a
+set_va!(body_aero, vel_app)
+
+if LINEARIZE
+    println("Linearize")
+    jac, res = VortexStepMethod.linearize(
+        solver, 
+        body_aero, 
+        [zeros(4); vel_app; zeros(3)];
+        theta_idxs=1:4,
+        va_idxs=5:7,
+        omega_idxs=8:10,
+        moment_frac=0.1)
+    @time jac, res = VortexStepMethod.linearize(
+        solver, 
+        body_aero, 
+        [zeros(4); vel_app; zeros(3)]; 
+        theta_idxs=1:4, 
+        va_idxs=5:7, 
+        omega_idxs=8:10,
+        moment_frac=0.1)
+end
+
+# Plotting polar data
+PLOT && plot_polar_data(body_aero)
+
+# Plotting geometry
+PLOT && plot_geometry(
+    body_aero,
+    "";
+    data_type=".svg",
+    save_path="",
+    is_save=false,
+    is_show=true,
+    view_elevation=15,
+    view_azimuth=-120,
+    use_tex=USE_TEX
+)
+
+# Solving and plotting distributions
+println("Solve")
+results = VortexStepMethod.solve(solver, body_aero; log=true)
+@time VortexStepMethod.solve(solver, body_aero; log=true)
+
+body_y_coordinates = [panel.aero_center[2] for panel in body_aero.panels]
+
+PLOT && plot_distribution(
+    [body_y_coordinates],
+    [results],
+    ["VSM"];
+    title="CAD_spanwise_distributions_alpha_$(round(aoa, digits=1))_delta_$(round(side_slip, digits=1))_yaw_$(round(yaw_rate, digits=1))_v_a_$(round(v_a, digits=1))",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+PLOT && plot_polars(
+    [solver],
+    [body_aero],
+    [
+        "VSM from Ram Air Kite OBJ and DAT file",
+    ];
+    angle_range=range(0, 20, length=20),
+    angle_type="angle_of_attack",
+    angle_of_attack=0,
+    side_slip=0,
+    v_a=10,
+    title="ram_kite_panels_$(wing.n_panels)_distribution_$(wing.spanwise_distribution)",
+    data_type=".pdf",
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+nothing

--- a/examples_cp/rectangular_wing.jl
+++ b/examples_cp/rectangular_wing.jl
@@ -1,0 +1,98 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using LinearAlgebra
+using ControlPlots
+using VortexStepMethod
+
+PLOT = true
+USE_TEX = false
+
+# Step 1: Define wing parameters
+n_panels = 20          # Number of panels
+span = 20.0            # Wing span [m]
+chord = 1.0            # Chord length [m]
+v_a = 20.0             # Magnitude of inflow velocity [m/s]
+density = 1.225        # Air density [kg/m³]
+alpha_deg = 30.0       # Angle of attack [degrees]
+alpha = deg2rad(alpha_deg)
+
+# Step 2: Create wing geometry with linear panel distribution
+wing = Wing(n_panels, spanwise_distribution=LINEAR)
+
+# Add wing sections - defining only tip sections with inviscid airfoil model
+add_section!(wing,
+    [0.0, span/2, 0.0],   # Left tip LE
+    [chord, span/2, 0.0],  # Left tip TE
+    INVISCID)
+add_section!(wing,
+    [0.0, -span/2, 0.0],  # Right tip LE
+    [chord, -span/2, 0.0], # Right tip TE
+    INVISCID)
+
+# Refine mesh
+refine!(wing)
+
+# Step 3: Initialize aerodynamics
+body_aero = BodyAerodynamics([wing])
+
+# Set inflow conditions
+vel_app = [cos(alpha), 0.0, sin(alpha)] .* v_a
+set_va!(body_aero, vel_app, [0, 0, 0.1])
+
+# Step 4: Initialize solvers for both LLT and VSM methods
+llt_solver = Solver(body_aero; aerodynamic_model_type=LLT)
+vsm_solver = Solver(body_aero; aerodynamic_model_type=VSM)
+
+# Step 5: Solve using both methods
+results_llt = solve(llt_solver, body_aero)
+@time results_llt = solve(llt_solver, body_aero)
+results_vsm = solve(vsm_solver, body_aero)
+@time results_vsm = solve(vsm_solver, body_aero)
+
+# Print results comparison
+println("\nLifting Line Theory Results:")
+println("CL = $(round(results_llt["cl"], digits=4))")
+println("CD = $(round(results_llt["cd"], digits=4))")
+println("\nVortex Step Method Results:")
+println("CL = $(round(results_vsm["cl"], digits=4))")
+println("CD = $(round(results_vsm["cd"], digits=4))")
+println("Projected area = $(round(results_vsm["projected_area"], digits=4)) m²")
+
+# Step 6: Plot geometry
+PLOT && plot_geometry(
+      body_aero,
+      "Rectangular_wing_geometry";
+      data_type=".pdf",
+      save_path=".",
+      is_save=false,
+      is_show=true,
+      use_tex=USE_TEX
+)
+
+# Step 7: Plot spanwise distributions
+y_coordinates = [panel.aero_center[2] for panel in body_aero.panels]
+
+PLOT && plot_distribution(
+    [y_coordinates, y_coordinates],
+    [results_vsm, results_llt],
+    ["VSM", "LLT"],
+    title="Spanwise Distributions",
+    use_tex=USE_TEX
+)
+
+# Step 8: Plot polar curves
+angle_range = range(0, 20, 20)
+PLOT && plot_polars(
+    [llt_solver, vsm_solver],
+    [body_aero, body_aero],
+    ["LLT", "VSM"];
+    angle_range,
+    angle_type="angle_of_attack",
+    v_a,
+    title="Rectangular Wing Polars",
+    use_tex=USE_TEX
+)
+nothing

--- a/examples_cp/rectangular_wing.jl
+++ b/examples_cp/rectangular_wing.jl
@@ -48,9 +48,9 @@ vsm_solver = Solver(body_aero; aerodynamic_model_type=VSM)
 
 # Step 5: Solve using both methods
 results_llt = solve(llt_solver, body_aero)
-@time results_llt = solve(llt_solver, body_aero)
 results_vsm = solve(vsm_solver, body_aero)
-@time results_vsm = solve(vsm_solver, body_aero)
+@time solve(llt_solver, body_aero)
+@time solve(vsm_solver, body_aero)
 
 # Print results comparison
 println("\nLifting Line Theory Results:")

--- a/examples_cp/stall_model.jl
+++ b/examples_cp/stall_model.jl
@@ -1,0 +1,143 @@
+using Pkg
+if !("ControlPlots" ∈ keys(Pkg.project().dependencies))
+    Pkg.activate(@__DIR__)
+end
+
+using ControlPlots
+using LinearAlgebra
+using VortexStepMethod
+
+using CSV
+using DataFrames
+
+PLOT = true
+USE_TEX = false
+
+# Find root directory
+root_dir = dirname(@__DIR__)
+save_folder = joinpath(root_dir, "results", "TUDELFT_V3_KITE")
+mkpath(save_folder)
+
+# Defining discretisation
+n_panels = 54
+spanwise_distribution = SPLIT_PROVIDED
+
+# Load rib data from CSV
+csv_file_path = joinpath(
+    root_dir,
+    "data",
+    "TUDELFT_V3_KITE",
+    "rib_list_from_CAD_LE_TE_and_surfplan_d_tube_camber_19ribs.csv"
+)
+
+df = CSV.read(csv_file_path, DataFrame)
+rib_list = []
+for row in eachrow(df)
+    LE = [row.LE_x, row.LE_y, row.LE_z]
+    TE = [row.TE_x, row.TE_y, row.TE_z]
+    push!(rib_list, (LE, TE, LEI_AIRFOIL_BREUKELS, (row.d_tube, row.camber)))
+end
+
+# Create wing geometry
+# n_unrefined_sections will be automatically set to the number of ribs (18 sections)
+CAD_wing = Wing(n_panels; spanwise_distribution)
+for rib in rib_list
+    add_section!(CAD_wing, rib[1], rib[2], rib[3], rib[4])
+end
+refine!(CAD_wing)
+body_aero = BodyAerodynamics([CAD_wing])
+
+# Create solvers
+vsm_solver = Solver(body_aero;
+    aerodynamic_model_type=VSM,
+    is_with_artificial_damping=false
+)
+VSM_with_stall_correction = Solver(body_aero;
+    aerodynamic_model_type=VSM,
+    is_with_artificial_damping=true
+)
+
+# Setting velocity conditions
+v_a = 15.0
+aoa = 17.0
+side_slip = 0.0
+yaw_rate = 0.0
+aoa_rad = deg2rad(aoa)
+vel_app = [
+    cos(aoa_rad) * cos(side_slip),
+    sin(side_slip),
+    sin(aoa_rad)
+] * v_a
+set_va!(body_aero, vel_app)
+
+# Plotting geometry
+PLOT && plot_geometry(
+    body_aero,
+    "";
+    data_type=".svg",
+    save_path="",
+    is_save=false,
+    is_show=true,
+    view_elevation=15,
+    view_azimuth=-120,
+    use_tex=USE_TEX
+)
+
+# Solving and plotting distributions
+results = solve(vsm_solver, body_aero)
+@time results_with_stall = solve(VSM_with_stall_correction, body_aero)
+@time results_with_stall = solve(VSM_with_stall_correction, body_aero)
+
+CAD_y_coordinates = [panel.aero_center[2] for panel in body_aero.panels]
+
+PLOT && plot_distribution(
+    [CAD_y_coordinates, CAD_y_coordinates],
+    [results, results_with_stall],
+    ["VSM", "VSM with stall correction"];
+    title="CAD_spanwise_distributions_alpha_$(round(aoa, digits=1))_delta_$(round(side_slip, digits=1))_yaw_$(round(yaw_rate, digits=1))_v_a_$(round(v_a, digits=1))",
+    data_type=".pdf",
+    save_path=joinpath(save_folder, "spanwise_distributions"),
+    is_save=false,
+    is_show=true,
+    use_tex=USE_TEX
+)
+
+# Plotting polar
+save_path = joinpath(root_dir, "results", "TUDELFT_V3_KITE")
+path_cfd_lebesque = joinpath(
+    root_dir,
+    "data",
+    "TUDELFT_V3_KITE",
+    "literature_results",
+    "V3_CL_CD_RANS_Lebesque_2024_Rey_300e4.csv"
+)
+
+# Only include literature data if file exists
+literature_paths = isfile(path_cfd_lebesque) ? [path_cfd_lebesque] : String[]
+
+labels = [
+    "VSM CAD 19ribs",
+    "VSM CAD 19ribs , with stall correction"
+]
+if !isempty(literature_paths)
+    push!(labels, "CFD_Lebesque Rey 30e5")
+end
+
+PLOT && plot_polars(
+    [vsm_solver, VSM_with_stall_correction],
+    [body_aero, body_aero],
+    labels;
+    literature_path_list=literature_paths,
+    angle_range=range(0, 25, length=25),
+    angle_type="angle_of_attack",
+    angle_of_attack=aoa,
+    side_slip=side_slip,
+    v_a=v_a,
+    title="tutorial_testing_stall_model_n_panels_$(n_panels)_distribution_$(spanwise_distribution)",
+    data_type=".pdf",
+    save_path=joinpath(save_folder, "polars"),
+    is_save=true,
+    is_show=true,
+    use_tex=USE_TEX
+)
+nothing

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -62,7 +62,10 @@ function VortexStepMethod.save_plot(fig, save_path, title; data_type=".pdf")
     @debug "Current working directory: $(pwd())"
 
     try
-        fig.savefig(full_path)
+        hasproperty(fig, :savefig) || throw(ArgumentError(
+            "Figure object of type $(typeof(fig)) does not support savefig()."
+        ))
+        getproperty(fig, :savefig)(full_path)
         @debug "Figure saved as $data_type"
 
         if isfile(full_path)
@@ -658,20 +661,29 @@ function VortexStepMethod.plot_polars(
     # Load literature data if provided
     if !isempty(literature_path_list)
         for path in literature_path_list
-            data = readdlm(path, ',')
-            header = lowercase.(string.(data[1, :]))
+            raw_data = readdlm(path, ',')
+            table, header = if raw_data isa Tuple
+                # readdlm(...; header=true) returns (data, header)
+                raw_table, raw_header = raw_data
+                raw_table, lowercase.(string.(vec(raw_header)))
+            else
+                # Header is in first row when a single matrix is returned
+                raw_data[2:end, :], lowercase.(string.(raw_data[1, :]))
+            end
             # Find column indices for alpha, CL, CD, CS (case-insensitive, allow common variants)
             alpha_idx = findfirst(x -> occursin("alpha", x) || x == "aoa", header)
             cl_idx    = findfirst(x -> occursin("cl", x), header)
             cd_idx    = findfirst(x -> occursin("cd", x), header)
             cs_idx    = findfirst(x -> occursin("cs", x), header)
+            (isnothing(alpha_idx) || isnothing(cl_idx) || isnothing(cd_idx)) &&
+                throw(ArgumentError("Literature CSV must contain alpha/aoa, cl and cd columns: $path"))
             # Fallback: if CS not found, fill with zeros
-            cs_col = cs_idx === nothing ? zeros(size(data, 1)-1) : data[2:end, cs_idx]
+            cs_col = cs_idx === nothing ? zeros(size(table, 1)) : table[:, cs_idx]
             # Push as [alpha, CL, CD, CS]
             push!(polar_data_list, [
-                data[2:end, alpha_idx],
-                data[2:end, cl_idx],
-                data[2:end, cd_idx],
+                table[:, alpha_idx],
+                table[:, cl_idx],
+                table[:, cd_idx],
                 cs_col
             ])
         end

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -660,7 +660,7 @@ function VortexStepMethod.plot_polars(
             data = readdlm(path, ',')
             header = lowercase.(string.(data[1, :]))
             # Find column indices for alpha, CL, CD, CS (case-insensitive, allow common variants)
-            alpha_idx = findfirst(x -> occursin("alpha", x), header)
+            alpha_idx = findfirst(x -> occursin("alpha", x) || x == "aoa", header)
             cl_idx    = findfirst(x -> occursin("cl", x), header)
             cd_idx    = findfirst(x -> occursin("cd", x), header)
             cs_idx    = findfirst(x -> occursin("cs", x), header)

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -92,7 +92,7 @@ Display a plot at specified DPI.
 # Keyword arguments
 - `dpi`: Dots per inch for the figure (default: 130)
 """
-function VortexStepMethod.show_plot(fig; dpi=130)
+function VortexStepMethod.show_plot(fig::plt.Figure; dpi=130)
     fig.set_dpi(dpi)
     plt.display(fig)
 end

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -174,7 +174,11 @@ function create_geometry_plot(body_aero::BodyAerodynamics, title, view_elevation
     set_plot_style(28; use_tex)
 
     panels = body_aero.panels
-    va = isa(body_aero.va, Tuple) ? body_aero.va[1] : body_aero.va
+    va = if body_aero.has_distributed_va
+        panels[1].va
+    else
+        isa(body_aero.va, Tuple) ? body_aero.va[1] : body_aero.va
+    end
 
     # Extract geometric data
     corner_points = [panel.corner_points for panel in panels]

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -174,8 +174,10 @@ function create_geometry_plot(body_aero::BodyAerodynamics, title, view_elevation
     set_plot_style(28; use_tex)
 
     panels = body_aero.panels
+    isempty(panels) && throw(ArgumentError("Cannot plot geometry: body_aero.panels is empty."))
+
     va = if body_aero.has_distributed_va
-        panels[1].va
+        body_aero._va
     else
         isa(body_aero.va, Tuple) ? body_aero.va[1] : body_aero.va
     end

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -90,6 +90,7 @@ Display a plot at specified DPI.
 - `dpi`: Dots per inch for the figure (default: 130)
 """
 function VortexStepMethod.show_plot(fig; dpi=130)
+    fig.set_dpi(dpi)
     plt.display(fig)
 end
 
@@ -183,7 +184,6 @@ function create_geometry_plot(body_aero::BodyAerodynamics, title, view_elevation
     end
 
     # Extract geometric data
-    corner_points = [panel.corner_points for panel in panels]
     control_points = [panel.control_point for panel in panels]
     aero_centers = [panel.aero_center for panel in panels]
 
@@ -239,7 +239,6 @@ function create_geometry_plot(body_aero::BodyAerodynamics, title, view_elevation
     plot_line_segment!(ax, [va_vector_begin, va_vector_end], :lightblue, "va")
 
     # Add legends for the first occurrence of each label
-    handles, labels = ax.get_legend_handles_labels()
     # by_label = Dict(zip(labels, handles))
     # ax.legend(values(by_label), keys(by_label), bbox_to_anchor=(0, 0, 1.1, 1))
 
@@ -520,6 +519,8 @@ function generate_polar_data(
     v_a=10.0,
     use_latex=false
 )
+    _ = use_latex
+
     n_panels = length(body_aero.panels)
     n_angles = length(angle_range)
 
@@ -532,9 +533,6 @@ function generate_polar_data(
     cd_distribution = zeros(n_angles, n_panels)
     cs_distribution = zeros(n_angles, n_panels)
     reynolds_number = zeros(n_angles)
-
-    # Previous gamma for initialization
-    gamma = nothing
 
     for (i, angle_i) in enumerate(angle_range)
         # Set angle based on type
@@ -569,9 +567,6 @@ function generate_polar_data(
         cd_distribution[i, :] = results["cd_distribution"]
         cs_distribution[i, :] = results["cs_distribution"]
         reynolds_number[i] = results["Rey"]
-
-        # Store gamma for next iteration
-        gamma = gamma_distribution[i, :]
     end
 
     polar_data = [
@@ -896,7 +891,7 @@ function VortexStepMethod.plot_polar_data(body_aero::BodyAerodynamics;
         use_tex = false
         )
     if body_aero.panels[1].aero_model == POLAR_MATRICES
-        set_plot_style()
+    set_plot_style(; use_tex)
 
         # Create figure with subplots
         fig = plt.figure(figsize=(15, 6))

--- a/ext/VortexStepMethodControlPlotsExt.jl
+++ b/ext/VortexStepMethodControlPlotsExt.jl
@@ -693,30 +693,6 @@ function VortexStepMethod.plot_polars(
     if !isempty(literature_path_list)
         for path in literature_path_list
             raw_data = readdlm(path, ',')
-            table, header = if raw_data isa Tuple
-                # readdlm(...; header=true) returns (data, header)
-                raw_table, raw_header = raw_data
-                raw_table, lowercase.(string.(vec(raw_header)))
-            else
-                # Header is in first row when a single matrix is returned
-                raw_data[2:end, :], lowercase.(string.(raw_data[1, :]))
-            end
-            # Find column indices for alpha, CL, CD, CS (case-insensitive, allow common variants)
-            alpha_idx = findfirst(x -> occursin("alpha", x) || x == "aoa", header)
-            cl_idx    = findfirst(x -> occursin("cl", x), header)
-            cd_idx    = findfirst(x -> occursin("cd", x), header)
-            cs_idx    = findfirst(x -> occursin("cs", x), header)
-            (isnothing(alpha_idx) || isnothing(cl_idx) || isnothing(cd_idx)) &&
-                throw(ArgumentError("Literature CSV must contain alpha/aoa, cl and cd columns: $path"))
-            # Fallback: if CS not found, fill with zeros
-            cs_col = cs_idx === nothing ? zeros(size(table, 1)) : table[:, cs_idx]
-            # Push as [alpha, CL, CD, CS]
-            push!(polar_data_list, [
-                table[:, alpha_idx],
-                table[:, cl_idx],
-                table[:, cd_idx],
-                cs_col
-            ])
             push!(polar_data_list, _extract_literature_polar_data(raw_data, path))
         end
     end

--- a/ext/VortexStepMethodMakieExt.jl
+++ b/ext/VortexStepMethodMakieExt.jl
@@ -249,7 +249,7 @@ Save a Makie figure to a file.
 # Keyword arguments
 - `data_type`: File extension (default: ".png", also supports ".jpeg")
 """
-function VortexStepMethod.save_plot(fig, save_path, title; data_type=".png")
+function VortexStepMethod.save_plot(fig::Makie.Figure, save_path, title; data_type=".png")
     isnothing(save_path) && throw(ArgumentError("save_path should be provided"))
 
     !isdir(save_path) && mkpath(save_path)
@@ -286,7 +286,7 @@ Display a Makie figure.
 # Keyword arguments
 - `dpi`: Dots per inch for the figure (default: 130) - currently unused in Makie
 """
-function VortexStepMethod.show_plot(fig; dpi=130)
+function VortexStepMethod.show_plot(fig::Makie.Figure; dpi=130)
     display(fig)
 end
 

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -84,6 +84,12 @@ end
     else
         @test fig !== nothing
     end
+
+    if backend == "Makie"
+        @test hasmethod(VortexStepMethod.show_plot, Tuple{Figure})
+        @test_throws MethodError VortexStepMethod.show_plot(nothing)
+    end
+
     @test isfile(joinpath(save_dir,
                           "Rectangular_wing_geometry_angled_view.png"))
     safe_rm(joinpath(save_dir,

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -215,6 +215,15 @@ end
     end
 
     if backend == "ControlPlots"
+        body_aero_empty = create_body_aero()
+        empty!(body_aero_empty.panels)
+        @test_throws ArgumentError plot_geometry(
+            body_aero_empty,
+            "Rectangular_wing_geometry_empty_panels";
+            is_save=false,
+            is_show=false,
+        )
+
         body_aero_distributed = create_body_aero()
         n_panels = length(body_aero_distributed.panels)
         va_distribution = repeat([12.0 0.0 1.0], n_panels, 1)

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -88,6 +88,11 @@ end
     if backend == "Makie"
         @test hasmethod(VortexStepMethod.show_plot, Tuple{Figure})
         @test_throws MethodError VortexStepMethod.show_plot(nothing)
+        @test_nowarn VortexStepMethod.show_plot(fig)
+    else
+        FigType = plt.Figure
+        @test hasmethod(VortexStepMethod.show_plot, Tuple{FigType})
+        @test_throws MethodError VortexStepMethod.show_plot(nothing)
     end
 
     @test isfile(joinpath(save_dir,

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -213,5 +213,30 @@ end
     else
         @test fig !== nothing
     end
+
+    if backend == "ControlPlots"
+        literature_csv = joinpath(tempdir(), "polar_literature_aoa.csv")
+        open(literature_csv, "w") do io
+            write(io, "aoa,cl,cd,cs\n")
+            write(io, "0.0,0.1,0.01,0.0\n")
+            write(io, "5.0,0.5,0.02,0.01\n")
+            write(io, "10.0,0.9,0.04,0.02\n")
+        end
+
+        try
+            fig = plot_polars(
+                Solver[],
+                BodyAerodynamics[],
+                ["Literature"],
+                literature_path_list=[literature_csv],
+                title="Literature AOA Header",
+                is_save=false,
+                is_show=false,
+            )
+            @test fig !== nothing
+        finally
+            safe_rm(literature_csv)
+        end
+    end
 end
 nothing

--- a/test/plotting/test_plotting.jl
+++ b/test/plotting/test_plotting.jl
@@ -215,9 +215,23 @@ end
     end
 
     if backend == "ControlPlots"
+        body_aero_distributed = create_body_aero()
+        n_panels = length(body_aero_distributed.panels)
+        va_distribution = repeat([12.0 0.0 1.0], n_panels, 1)
+        set_va!(body_aero_distributed, va_distribution)
+
+        @test body_aero_distributed.has_distributed_va
+        fig = plot_geometry(
+            body_aero_distributed,
+            "Rectangular_wing_geometry_distributed_va";
+            is_save=false,
+            is_show=false,
+        )
+        @test fig !== nothing
+
         literature_csv = joinpath(tempdir(), "polar_literature_aoa.csv")
         open(literature_csv, "w") do io
-            write(io, "aoa,cl,cd,cs\n")
+            write(io, "AOA,cl,cd,cs\n")
             write(io, "0.0,0.1,0.01,0.0\n")
             write(io, "5.0,0.5,0.02,0.01\n")
             write(io, "10.0,0.9,0.04,0.02\n")


### PR DESCRIPTION
- [x] Add examples using ControlPlots.jl to the folder examples_cp
- [x] Make examples_cp a subproject
- [x] remove ControPlots from examples/Project.toml
- [x] Address remarks of Copilot
- [x] Fix JETLS warnings
- [x] Update jetls_examples

**Rational:**
This keeps the old examples available. The old plots are better suited for publication purposes. Uwe will be responsible for maintaining this set of examples.

**Advantages of using ControlPlots.jl:**
- faster time-to-first-plot
- better publication quality because a full LaTeX installation can be used for formatting
- menu-driven option to save plots in pdf format
- easier to port new plots from updated versions of the Python version of VortexStepMethod

**Disadvantages:**
- not always thread safe
- might fail on some computers because compatible Python and Matplotlib versions must be installed