### PR TITLE
Fix lofted-airfoil rib placement for +spanwise section order

### DIFF
--- a/ext/VortexStepMethodMakieExt.jl
+++ b/ext/VortexStepMethodMakieExt.jl
@@ -136,9 +136,6 @@ function airfoil_skin_geometry(body; R_b_w=nothing, T_b_w=nothing)
         n = length(sections)
         n_panels = n - 1
         n_panels < 1 && continue
-        spanwise = Point3f(wing.spanwise_direction)
-        increasing = dot(Point3f(sections[n].LE_point) -
-                         Point3f(sections[1].LE_point), spanwise) > 0
         for (i, section) in enumerate(sections)
             isnothing(section.section_aero) && continue
             panel_idx = panel_offset + min(i, n_panels)
@@ -147,9 +144,9 @@ function airfoil_skin_geometry(body; R_b_w=nothing, T_b_w=nothing)
             corners = panel.corner_points
             corner1 = Point3f(corners[:, 1]); corner3 = Point3f(corners[:, 3])
             corner2 = Point3f(corners[:, 2]); corner4 = Point3f(corners[:, 4])
-            plus_edge = i <= n_panels ? !increasing : increasing
-            leading = plus_edge ? corner1 : corner4
-            trailing = plus_edge ? corner2 : corner3
+            first_edge = i <= n_panels
+            leading = first_edge ? corner1 : corner4
+            trailing = first_edge ? corner2 : corner3
             chord = trailing - leading
             chord_len = norm(chord)
             chord_len < 1e-9 && continue


### PR DESCRIPTION
## Problem

In the Makie extension, `airfoil_skin_geometry` draws one lofted airfoil rib per section by fitting the section's contour onto a panel edge. It picked the edge with:

```julia
plus_edge = i <= n_panels ? !increasing : increasing
```

where `increasing` tests whether `refined_sections` run along `+spanwise`.

Panels are always built with `refined_sections[p]` → `corner_points` col 1/2 and `refined_sections[p+1]` → col 4/3 (`init_pos!`), **independent of span order**. So the edge for section `i` is purely index-based:

- `i <= n_panels` → panel `i`'s first edge (col 1/2)
- `i == n` (last section) → last panel's second edge (col 4/3)

The `increasing` term is spurious. It is a no-op for `−spanwise` wings (`increasing == false`) but **inverts every mapping** for `+spanwise` wings (`increasing == true`): each section's contour is lofted onto its neighbour's station. The result is a **missing rib at the first-section tip** and a **doubled/folded rib at the last-section tip**, while the VSM panels themselves render correctly.

Observed on an SK100 wing (sections ordered −y→+y): no lofted airfoil at the most-negative-y tip, a folded double airfoil at the most-positive-y tip.

## Fix

```julia
first_edge = i <= n_panels
```

This reproduces the previous (correct) output for `−spanwise` wings and fixes the `+spanwise` case. `spanwise`/`increasing` are no longer needed and are removed.

## Notes

- Plotting-only change; no effect on aero results.
- Changelog left to the maintainer's release batching, matching recent post-release commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)